### PR TITLE
Add support for x-kubernetes-map-type

### DIFF
--- a/pkg/crd/markers/topology.go
+++ b/pkg/crd/markers/topology.go
@@ -58,8 +58,7 @@ type ListType string
 type ListMapKey string
 
 // +controllertools:marker:generateHelp:category="CRD processing"
-
-// MapType specifies the level of atomicity of the map,
+// MapType specifies the level of atomicity of the map;
 // i.e. whether each item in the map is independent of the others,
 // or all fields are treated as a single unit.
 //
@@ -69,7 +68,6 @@ type ListMapKey string
 // This is the default behavior.
 // - "atomic": all fields are treated as one unit.
 // Any changes have to replace the entire map.
-
 type MapType string
 
 func (l ListType) ApplyToSchema(schema *apiext.JSONSchemaProps) error {

--- a/pkg/crd/markers/zz_generated.markerhelp.go
+++ b/pkg/crd/markers/zz_generated.markerhelp.go
@@ -106,6 +106,17 @@ func (ListType) Help() *markers.DefinitionHelp {
 	}
 }
 
+func (MapType) Help() *markers.DefinitionHelp {
+	return &markers.DefinitionHelp{
+		Category: "CRD processing",
+		DetailedHelp: markers.DetailedHelp{
+			Summary: "specifies the level of atomicity of the map; i.e. whether each item in the map is independent of the others, or all fields are treated as a single unit. ",
+			Details: "Possible values: - \"granular\": items in the map are independent of each other, and can be manipulated by different actors. This is the default behavior. - \"atomic\": all fields are treated as one unit. Any changes have to replace the entire map.",
+		},
+		FieldHelp: map[string]markers.DetailedHelp{},
+	}
+}
+
 func (MaxItems) Help() *markers.DefinitionHelp {
 	return &markers.DefinitionHelp{
 		Category: "CRD validation",

--- a/pkg/crd/markers/zz_generated.markerhelp.go
+++ b/pkg/crd/markers/zz_generated.markerhelp.go
@@ -86,7 +86,7 @@ func (Format) Help() *markers.DefinitionHelp {
 
 func (ListMapKey) Help() *markers.DefinitionHelp {
 	return &markers.DefinitionHelp{
-		Category: "CRD topology",
+		Category: "CRD processing",
 		DetailedHelp: markers.DetailedHelp{
 			Summary: "specifies the keys to map listTypes. ",
 			Details: "ListMapKey indicates the index of a map list. They can be repeated if multiple keys must be used. It can only be used when ListType is set to map, and the keys should be scalar types.",
@@ -97,7 +97,7 @@ func (ListMapKey) Help() *markers.DefinitionHelp {
 
 func (ListType) Help() *markers.DefinitionHelp {
 	return &markers.DefinitionHelp{
-		Category: "CRD topology",
+		Category: "CRD processing",
 		DetailedHelp: markers.DetailedHelp{
 			Summary: "specifies the type of data-structure that the list represents (map, set, atomic). ",
 			Details: "Possible data-structure types of a list are: - \"map\": it needs to have a key field, which will be used to build an associative list. A typical example is a the pod container list, which is indexed by the container name. - \"set\": Fields need to be \"scalar\", and there can be only one occurence of each. - \"atomic\": All the fields in the list are treated as a single value, are typically manipulated together by the same actor.",

--- a/pkg/crd/testdata/cronjob_types.go
+++ b/pkg/crd/testdata/cronjob_types.go
@@ -118,6 +118,10 @@ type CronJobSpec struct {
 	// +listMapKey=name
 	// +listMapKey=secondary
 	AssociativeList []AssociativeType `json:"associativeList"`
+
+	// A map that allows different actors to manage different fields
+	// +mapType=granular
+	MapOfInfo map[string][]byte `json:"mapOfInfo"`
 }
 
 type NestedObject struct {

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -122,6 +122,13 @@ spec:
                   a pointer to distinguish between explicit zero and not specified.
                 format: int32
                 type: integer
+              mapOfInfo:
+                description: A map that allows different actors to manage different fields
+                type: object
+                x-kubernetes-map-type: granular
+                additionalProperties:
+                  format: byte
+                  type: string
               jobTemplate:
                 description: Specifies the job that will be created when executing
                   a CronJob.
@@ -5019,6 +5026,7 @@ spec:
             - defaultedSlice
             - defaultedString
             - jobTemplate
+            - mapOfInfo
             - patternObject
             - schedule
             - twoOfAKindPart0


### PR DESCRIPTION
This PR adds support for the [`x-kubernetes-map-type` CRD annotation](https://github.com/kubernetes/kubernetes/pull/84113) in controller-tools.

Help appears under the `CRD processing` category due to https://github.com/kubernetes-sigs/controller-tools/pull/345#discussion_r343038026.