### PR TITLE
Add structType support

### DIFF
--- a/pkg/crd/markers/topology.go
+++ b/pkg/crd/markers/topology.go
@@ -127,8 +127,8 @@ func (m MapType) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
 func (m MapType) ApplyFirst() {}
 
 func (s StructType) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
-	if schema.Type != "object" {
-		return fmt.Errorf("must apply structType to an object")
+	if schema.Type != "object" && schema.Type != "" {
+		return fmt.Errorf("must apply structType to an object; either explicitly set or defaulted through an empty schema type")
 	}
 
 	if s != "atomic" && s != "granular" {

--- a/pkg/crd/markers/topology.go
+++ b/pkg/crd/markers/topology.go
@@ -124,8 +124,6 @@ func (m MapType) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
 	return nil
 }
 
-func (m MapType) ApplyFirst() {}
-
 func (s StructType) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
 	if schema.Type != "object" && schema.Type != "" {
 		return fmt.Errorf("must apply structType to an object; either explicitly set or defaulted through an empty schema type")
@@ -140,5 +138,3 @@ func (s StructType) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
 
 	return nil
 }
-
-func (s StructType) ApplyFirst() {}

--- a/pkg/crd/markers/zz_generated.markerhelp.go
+++ b/pkg/crd/markers/zz_generated.markerhelp.go
@@ -306,6 +306,17 @@ func (StorageVersion) Help() *markers.DefinitionHelp {
 	}
 }
 
+func (StructType) Help() *markers.DefinitionHelp {
+	return &markers.DefinitionHelp{
+		Category: "CRD processing",
+		DetailedHelp: markers.DetailedHelp{
+			Summary: "specifies the level of atomicity of the struct; i.e. whether each field in the struct is independent of the others, or all fields are treated as a single unit. ",
+			Details: "Possible values: - \"granular\": fields in the struct are independent of each other, and can be manipulated by different actors. This is the default behavior. - \"atomic\": all fields are treated as one unit. Any changes have to replace the entire struct.",
+		},
+		FieldHelp: map[string]markers.DetailedHelp{},
+	}
+}
+
 func (SubresourceScale) Help() *markers.DefinitionHelp {
 	return &markers.DefinitionHelp{
 		Category: "CRD",

--- a/pkg/crd/testdata/cronjob_types.go
+++ b/pkg/crd/testdata/cronjob_types.go
@@ -136,6 +136,10 @@ type CronJobSpec struct {
 	// A map that allows different actors to manage different fields
 	// +mapType=granular
 	MapOfInfo map[string][]byte `json:"mapOfInfo"`
+
+	// A struct that can only be entirely replaced
+	// +structType=atomic
+	StructWithSeveralFields NestedObject `json:"structWithSeveralFields"`
 }
 
 type NestedObject struct {

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -125,13 +125,6 @@ spec:
                   a pointer to distinguish between explicit zero and not specified.
                 format: int32
                 type: integer
-              mapOfInfo:
-                description: A map that allows different actors to manage different fields
-                type: object
-                x-kubernetes-map-type: granular
-                additionalProperties:
-                  format: byte
-                  type: string
               jobTemplate:
                 description: Specifies the job that will be created when executing
                   a CronJob.
@@ -4993,6 +4986,13 @@ spec:
                     - template
                     type: object
                 type: object
+              mapOfInfo:
+                description: A map that allows different actors to manage different fields
+                type: object
+                x-kubernetes-map-type: granular
+                additionalProperties:
+                  format: byte
+                  type: string
               noReallySuspend:
                 description: This flag is like suspend, but for when you really mean
                   it. It helps test the +kubebuilder:validation:Type marker.
@@ -5017,6 +5017,18 @@ spec:
                   type: array
                 description: This tests string slices are allowed as map values.
                 type: object
+              structWithSeveralFields:
+                description: A struct that can only be entirely replaced
+                type: object
+                x-kubernetes-map-type: atomic
+                properties:
+                  bar:
+                    type: boolean
+                  foo:
+                    type: string
+                required:
+                - bar
+                - foo
               successfulJobsHistoryLimit:
                 description: The number of successful finished jobs to retain. This
                   is a pointer to distinguish between explicit zero and not specified.
@@ -5064,6 +5076,7 @@ spec:
             - mapOfInfo
             - patternObject
             - schedule
+            - structWithSeveralFields
             - twoOfAKindPart0
             - twoOfAKindPart1
             - unprunedEmbeddedResource


### PR DESCRIPTION
Similarly to https://github.com/apelisse/controller-tools/pull/1, this PR adds a `+structType` marker, that maps to `x-kubernetes-map-type` in kube-openapi.

cc @apelisse 